### PR TITLE
[SDPTA-868] Remove unwanted slack notifications

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -92,7 +92,7 @@ jobs:
       always() &&
       ( inputs.slack_notify == 'always' ||
         ( inputs.slack_notify == 'release_only' && 
-          contains(fromJSON('["release/", "uat", "master", "standby", "production"]'), github.ref_name)
+          contains(fromJSON('["release", "uat", "master", "standby", "production"]'), github.ref_name)
         )
       )
     needs: [api]

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -102,7 +102,7 @@ jobs:
     with:
       workflow_name: BE API
       test_type: ":postman:"
-      test_subtype: ":smoke_test:"
+      test_subtype: ":smoke-test:"
       artifact_name: "core-test-report"
       be_url: ${{ inputs.be_url }}
       project: ${{ inputs.project }}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -91,22 +91,16 @@ jobs:
     if: |
       always() &&
       ( inputs.slack_notify == 'always' ||
-        ( inputs.slack_notify == 'release_only' &&
-          ( startsWith(github.ref_name, 'release/') ||
-            github.ref_name == 'uat_test' ||
-            github.ref_name == 'uat' ||
-            github.ref_name == 'master' ||
-            github.ref_name == 'production' ||
-            github.ref_name == 'standby'
-          )
+        ( inputs.slack_notify == 'release_only' && 
+          contains(fromJSON('["release/", "uat", "master", "standby", "production"]'), github.ref_name)
         )
       )
     needs: [api]
     secrets: inherit
     with:
       workflow_name: BE API
-      test_type: ":api:"
-      test_subtype: ":api:"
+      test_type: ":postman:"
+      test_subtype: ":smoke_test:"
       artifact_name: "core-test-report"
       be_url: ${{ inputs.be_url }}
       project: ${{ inputs.project }}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: true
         default: ""
+      slack_notify:
+        description: When to send the Slack notifications
+        type: string
+        required: false
+        default: "release_only"
 
 jobs:
   api:
@@ -83,7 +88,19 @@ jobs:
           path: /app/report/custom.collection.report.html
   notify_slack:
     uses: ./.github/workflows/notify_slack.yml
-    if: always()
+    if: |
+      always() &&
+      ( inputs.slack_notify == 'always' ||
+        ( inputs.slack_notify == 'release_only' &&
+          ( startsWith(github.ref_name, 'release/') ||
+            github.ref_name == 'uat_test' ||
+            github.ref_name == 'uat' ||
+            github.ref_name == 'master' ||
+            github.ref_name == 'production' ||
+            github.ref_name == 'standby'
+          )
+        )
+      )
     needs: [api]
     secrets: inherit
     with:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -91,8 +91,10 @@ jobs:
     if: |
       always() &&
       ( inputs.slack_notify == 'always' ||
-        ( inputs.slack_notify == 'release_only' && 
-          contains(fromJSON('["release", "uat", "master", "standby", "production"]'), github.ref_name)
+        ( inputs.slack_notify == 'release_only' &&
+          ( startsWith(github.ref_name, 'release/') ||
+            contains(fromJSON('["uat", "master", "standby", "production"]'), github.ref_name)
+          )
         )
       )
     needs: [api]

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -85,7 +85,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": "${{ inputs.test_type }} *<${{ github.event.repository.html_url }}|${{ github.repository }}> - Test <${{ env.LINK }}|${{ inputs.workflow_name }}> on ${{ env.BRANCH_LINK }} has passed.*"
+                          "text": "${{ inputs.test_type }}${{ inputs.test_subtype }} *<${{ github.event.repository.html_url }}|${{ github.repository }}> - Test <${{ env.LINK }}|${{ inputs.workflow_name }}> on ${{ env.BRANCH_LINK }} has passed.*"
                         }
                       },
                       {

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -120,7 +120,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "${{ inputs.test_type }} *<${{ github.event.repository.html_url }}|${{ github.repository }}> - Test <${{ env.LINK }}|${{ inputs.workflow_name }}> on ${{ env.BRANCH_LINK }} has failed.*"
+                        "text": "${{ inputs.test_type }}${{ inputs.test_subtype }} *<${{ github.event.repository.html_url }}|${{ github.repository }}> - Test <${{ env.LINK }}|${{ inputs.workflow_name }}> on ${{ env.BRANCH_LINK }} has failed.*"
                       }
                     },
                     {

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -44,6 +44,10 @@ on:
         test_type:
           type: string
           required: true
+        test_subtype:
+          type: string
+          required: false
+          default: ''
         runner:
           type: string
           required: false
@@ -158,16 +162,18 @@ jobs:
     if: |
       always() &&
       ( inputs.slack_notify == 'always' ||
-        ( inputs.slack_notify == 'release_only' && 
-          contains(fromJSON('["release", "uat", "master", "standby", "production"]'), github.ref_name)
+        ( inputs.slack_notify == 'release_only' &&
+          ( startsWith(github.ref_name, 'release/') ||
+            contains(fromJSON('["uat", "master", "standby", "production"]'), github.ref_name)
+          )
         )
       )
     needs: [run_e2e_be]
     secrets: inherit
     with:
       workflow_name: ${{ inputs.name }}
-      test_type: ":nightwatch:"
-      test_subtype: ":nightwatch:"
+      test_type: "{{ input.test_type }}"
+      test_subtype: "{{ input.test_subtype }}"
       artifact_name: "report-url"
       be_url: ${{ inputs.be_url }}
       project: ${{ inputs.project }}

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -173,8 +173,8 @@ jobs:
     secrets: inherit
     with:
       workflow_name: ${{ inputs.name }}
-      test_type: "{{ input.test_type }}"
-      test_subtype: "{{ input.test_subtype }}"
+      test_type: ${{ inputs.test_type }}
+      test_subtype: ${{ inputs.test_subtype }}
       artifact_name: "report-url"
       be_url: ${{ inputs.be_url }}
       project: ${{ inputs.project }}

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -153,7 +153,19 @@ jobs:
           path: /app/reports/report-url.txt
   notify_slack:
     uses: ./.github/workflows/notify_slack.yml
-    if: always()
+    if: |
+      always() &&
+      ( inputs.slack_notify == 'always' ||
+        ( inputs.slack_notify == 'release_only' &&
+          ( startsWith(github.ref_name, 'release/') ||
+            github.ref_name == 'uat_test' ||
+            github.ref_name == 'uat' ||
+            github.ref_name == 'master' ||
+            github.ref_name == 'production' ||
+            github.ref_name == 'standby'
+          )
+        )
+      )
     needs: [run_e2e_be]
     secrets: inherit
     with:

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -57,6 +57,11 @@ on:
           type: string
           required: false
           default: "sdp-test-report-dev"
+        slack_notify:
+          description: When to send the Slack notifications
+          type: string
+          required: false
+          default: "release_only"
         test_status:
           type: boolean
           default: false

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -159,7 +159,7 @@ jobs:
       always() &&
       ( inputs.slack_notify == 'always' ||
         ( inputs.slack_notify == 'release_only' && 
-          contains(fromJSON('["release/", "uat", "master", "standby", "production"]'), github.ref_name)
+          contains(fromJSON('["release", "uat", "master", "standby", "production"]'), github.ref_name)
         )
       )
     needs: [run_e2e_be]

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -158,14 +158,8 @@ jobs:
     if: |
       always() &&
       ( inputs.slack_notify == 'always' ||
-        ( inputs.slack_notify == 'release_only' &&
-          ( startsWith(github.ref_name, 'release/') ||
-            github.ref_name == 'uat_test' ||
-            github.ref_name == 'uat' ||
-            github.ref_name == 'master' ||
-            github.ref_name == 'production' ||
-            github.ref_name == 'standby'
-          )
+        ( inputs.slack_notify == 'release_only' && 
+          contains(fromJSON('["release/", "uat", "master", "standby", "production"]'), github.ref_name)
         )
       )
     needs: [run_e2e_be]

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -43,7 +43,8 @@ on:
           required: true
         test_type:
           type: string
-          required: true
+          required: false
+          default: ':e2e:'
         test_subtype:
           type: string
           required: false

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -153,7 +153,7 @@ jobs:
       always() &&
       ( inputs.slack_notify == 'always' ||
         ( inputs.slack_notify == 'release_only' && 
-          contains(fromJSON('["release/", "uat", "master", "standby", "production"]'), github.ref_name)
+          contains(fromJSON('["release", "uat", "master", "standby", "production"]'), github.ref_name)
         )
       )
     needs: [run_e2e_fe]

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -167,8 +167,8 @@ jobs:
     secrets: inherit
     with:
       workflow_name: ${{ inputs.name }}
-      test_type: "{{ input.test_type }}"
-      test_subtype: "{{ input.test_subtype }}"
+      test_type: ${{ inputs.test_type }}
+      test_subtype: ${{ inputs.test_subtype }}
       artifact_name: "report-url"
       fe_url: ${{ inputs.fe_url }}
       be_url: ${{ inputs.be_url }}

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -55,7 +55,8 @@ on:
         required: true
       test_type:
         type: string
-        required: true
+        required: false
+        default: ':e2e:'
       test_subtype:
         type: string
         required: false

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -56,6 +56,10 @@ on:
       test_type:
         type: string
         required: true
+      test_subtype:
+        type: string
+        required: false
+        default: ''
       runner:
         type: string
         required: false
@@ -152,16 +156,18 @@ jobs:
     if: |
       always() &&
       ( inputs.slack_notify == 'always' ||
-        ( inputs.slack_notify == 'release_only' && 
-          contains(fromJSON('["release", "uat", "master", "standby", "production"]'), github.ref_name)
+        ( inputs.slack_notify == 'release_only' &&
+          ( startsWith(github.ref_name, 'release/') ||
+            contains(fromJSON('["uat", "master", "standby", "production"]'), github.ref_name)
+          )
         )
       )
     needs: [run_e2e_fe]
     secrets: inherit
     with:
       workflow_name: ${{ inputs.name }}
-      test_type: ":nightwatch:"
-      test_subtype: ":nightwatch:"
+      test_type: "{{ input.test_type }}"
+      test_subtype: "{{ input.test_subtype }}"
       artifact_name: "report-url"
       fe_url: ${{ inputs.fe_url }}
       be_url: ${{ inputs.be_url }}

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -152,14 +152,8 @@ jobs:
     if: |
       always() &&
       ( inputs.slack_notify == 'always' ||
-        ( inputs.slack_notify == 'release_only' &&
-          ( startsWith(github.ref_name, 'release/') ||
-            github.ref_name == 'uat_test' ||
-            github.ref_name == 'uat' ||
-            github.ref_name == 'master' ||
-            github.ref_name == 'production' ||
-            github.ref_name == 'standby'
-          )
+        ( inputs.slack_notify == 'release_only' && 
+          contains(fromJSON('["release/", "uat", "master", "standby", "production"]'), github.ref_name)
         )
       )
     needs: [run_e2e_fe]

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -69,6 +69,11 @@ on:
         type: string
         required: false
         default: "sdp-test-report-dev"
+      slack_notify:
+        description: When to send the Slack notifications
+        type: string
+        required: false
+        default: "release_only"
 
 env:
   # Test users

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -144,7 +144,19 @@ jobs:
           path: /app/reports/report-url.txt
   notify_slack:
     uses: ./.github/workflows/notify_slack.yml
-    if: always()
+    if: |
+      always() &&
+      ( inputs.slack_notify == 'always' ||
+        ( inputs.slack_notify == 'release_only' &&
+          ( startsWith(github.ref_name, 'release/') ||
+            github.ref_name == 'uat_test' ||
+            github.ref_name == 'uat' ||
+            github.ref_name == 'master' ||
+            github.ref_name == 'production' ||
+            github.ref_name == 'standby'
+          )
+        )
+      )
     needs: [run_e2e_fe]
     secrets: inherit
     with:


### PR DESCRIPTION
As a dev/test engineer, I want no slack notifications to the sdp-test-report channel as the regression testing for a feature PR can be checked on the PR itself by developers, so it won’t send additional messages to the sdp-test-report channel.
Also fixed the slack notification test type emojis.