### PR TITLE
Add state input

### DIFF
--- a/.github/workflows/set_status.yml
+++ b/.github/workflows/set_status.yml
@@ -15,13 +15,24 @@ on:
         description: The target URL to associate with this status
         type: string
         required: false
+      state:
+        description: Check state to set
+        type: string
+        required: false
+        default: ""
 
 jobs:
   set_status:
     name: set_status
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
+      - name: Determine workflow state if not explicitly provided
+        uses: technote-space/workflow-conclusion-action@v3
+        if: ${{ inputs.state == '' }}
+      - name: Set explicitly provided workflow state
+        if: ${{ inputs.state != '' }}
+        run: |
+          echo "WORKFLOW_CONCLUSION=${{ inputs.state }}" >> $GITHUB_ENV
       - name: Set commit status in the GitHub API
         run: |
           curl -X POST \


### PR DESCRIPTION
1) Add an input for `state` to allow the status for check to be manually specified (e.g, to set a check as pending at the start of a workflow).