### PR TITLE
[DDS-1747] Use unique artefact name

### DIFF
--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -158,7 +158,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: report-url
+          name: ${{ inputs.name }}-report-url
           path: /app/reports/report-url.txt
   notify_slack:
     uses: ./.github/workflows/notify_slack.yml
@@ -177,7 +177,7 @@ jobs:
       workflow_name: ${{ inputs.name }}
       test_type: ${{ inputs.test_type }}
       test_subtype: ${{ inputs.test_subtype }}
-      artifact_name: "report-url"
+      artifact_name: "${{ inputs.name }}-report-url"
       be_url: ${{ inputs.be_url }}
       project: ${{ inputs.project }}
       slack_channel: ${{ inputs.slack_channel }}

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: report-url
+          name: ${{ inputs.name }}-report-url
           path: /app/reports/report-url.txt
   notify_slack:
     uses: ./.github/workflows/notify_slack.yml
@@ -169,7 +169,7 @@ jobs:
       workflow_name: ${{ inputs.name }}
       test_type: ${{ inputs.test_type }}
       test_subtype: ${{ inputs.test_subtype }}
-      artifact_name: "report-url"
+      artifact_name: "${{ inputs.name }}-report-url"
       fe_url: ${{ inputs.fe_url }}
       be_url: ${{ inputs.be_url }}
       project: ${{ inputs.project }}


### PR DESCRIPTION
1) Ensure that a unique artefact name is used when the e2e_fe/e2e_be jobs are used multiple times in a workflow.