### PR TITLE
[DEVOPS-323] Set database image snapshot during tide_build

### DIFF
--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Uncomment database snapshot environment variable
+        run: |
+          sed -i 's|# DB_IMAGE_SNAPSHOT|DB_IMAGE_SNAPSHOT|' .env
       # GitHub Actions does not support cloning to a custom path.
       - name: Copy repo
         run: |

--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -2,6 +2,9 @@ name: tide_build
 
 on: workflow_call
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   build_tide:
     name: tide_build
@@ -11,6 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Uncomment database snapshot environment variable
         run: |
           sed -i 's|# DB_IMAGE_SNAPSHOT|DB_IMAGE_SNAPSHOT|' .env

--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Uncomment database snapshot environment variable
         run: |
           sed -i 's|# DB_IMAGE_SNAPSHOT|DB_IMAGE_SNAPSHOT|' .env
+      - name: Print the contents of the .env file after modification
+        run: |
+          cat .env
       # GitHub Actions does not support cloning to a custom path.
       - name: Copy repo
         run: |

--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Uncomment database snapshot environment variable
         run: |
           sed -i 's|# DB_IMAGE_SNAPSHOT|DB_IMAGE_SNAPSHOT|' .env
-      - name: Print the contents of the .env file after modification
-        run: |
-          cat .env
       # GitHub Actions does not support cloning to a custom path.
       - name: Copy repo
         run: |
@@ -33,10 +30,6 @@ jobs:
       - name: Run build script
         run: |
           /app/.circleci/build.sh
-      - name: Run docker ps
-        if: always()
-        run: |
-          docker ps
       - name: Run test script
         if: always()
         run: |

--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Run build script
         run: |
           /app/.circleci/build.sh
+      - name: Run docker ps
+        if: always()
+        run: |
+          docker ps
       - name: Run test script
         if: always()
         run: |


### PR DESCRIPTION
1) Ensure the Tide Build and Test workflow uses the DB snapshot container.