### PR TITLE
Use large runner for DB image build

### DIFF
--- a/.github/workflows/run_db_trigger.yml
+++ b/.github/workflows/run_db_trigger.yml
@@ -37,7 +37,7 @@ env:
     
 jobs:
   export-db:
-    runs-on: ubuntu-latest
+    runs-on: biggy
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
1) The standard runner only has 14GB of disk space, which causes OOM during the image build process for projects with large DBs.