### PR TITLE
[DEVOPS-393] Manually trigger build after export-config

### DIFF
--- a/.github/workflows/export_config.yml
+++ b/.github/workflows/export_config.yml
@@ -39,3 +39,13 @@ jobs:
         run: |
           cd /app
           /app/.circleci/export-config.sh
+      - name: Get the release branch
+        run: |
+          CURRENT_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+          echo RELEASE_GIT_BRANCH="${CURRENT_GIT_BRANCH//automation/release}" >> $GITHUB_ENV
+      - name: Manually run build workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: build
+          repo: ${{ secrets.GITHUB_REPOSITORY }}
+          ref: ${{ env.RELEASE_GIT_BRANCH }}

--- a/.github/workflows/export_config.yml
+++ b/.github/workflows/export_config.yml
@@ -47,5 +47,5 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: build
-          repo: ${{ secrets.GITHUB_REPOSITORY }}
+          repo: ${{ github.repository }}
           ref: ${{ env.RELEASE_GIT_BRANCH }}

--- a/.github/workflows/set_status.yml
+++ b/.github/workflows/set_status.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Set commit status in the GitHub API
         run: |
           curl -X POST \
+          -vvv \
           -H "Authorization: token ${{ secrets.SDPDEPLOY_PAT }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \

--- a/.github/workflows/set_status.yml
+++ b/.github/workflows/set_status.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           curl -X POST \
           -vvv \
-          -H "Authorization: token ${{ secrets.SDPDEPLOY_PAT }}" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
           -d "{


### PR DESCRIPTION
1) Manually call the `build` workflow after running the export-config.sh script, as commits published as part of an Actions run won't trigger workflows that would ordinarily run with `on: push`.