### PR TITLE
Further fixes for incorrect reporting

### DIFF
--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -25,11 +25,11 @@ on:
         required: true
       workflow_id:
         type: string
-        required: false
+        required: true
         default: ""
       workflow_reusable_name:
         type: string
-        required: false
+        required: true
         default: ""
       project:
         description: Lagoon project name
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+    - name: Wait 15s for previous jobs to conclude
+      run: sleep 15
     - uses: dpc-sdp/workflow-conclusion-action@main
       with:
         JOB_ID: ${{ inputs.workflow_id }}


### PR DESCRIPTION
1) Make `workflow_id ` and `workflow_reusable_name ` required (these parameters are already implemented by the caller workflows).
2) The GitHub API occasionally reports the status of previously run jobs as 'in_progress', even though there is a `needs` statement to indicate a dependency. I've added a 15 second sleep before actually starting the job to hopefully work around this.