### PR TITLE
[SDPTA-932] Rename Circle Branch

### DIFF
--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -103,7 +103,7 @@ env:
   # Settings
   TESTID: ${{ inputs.test_id }}
   NIGHTWATCH_OUTPUT: true
-  CIRCLE_BRANCH: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
+  GIT_BRANCH: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
   EYES_APPNAME: ${{ inputs.eyes_appname }}
 
 jobs:
@@ -140,7 +140,7 @@ jobs:
           echo $BE_BASE_URL
           echo $FE_BASE_URL
           echo $PROJECT
-          echo $CIRCLE_BRANCH
+          echo $GIT_BRANCH
       -
         name: "Wait up servers in case they are idle"
         run: |


### PR DESCRIPTION
Rename CIRCLE_BRANCH with GIT_BRANCH to better reflect name as we don't use Circle CI anymore

sdp-testing uses it for some applitools config for nightly
<img width="633" alt="image" src="https://github.com/dpc-sdp/github-actions/assets/86580032/2c2b5ad6-d214-4bb9-b4f4-2a25c2b4bfc7">
