### PR TITLE
[SDPAP-9391] Bump ci-builder image tag

### DIFF
--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -22,7 +22,7 @@ jobs:
     name: tide_build
     runs-on: ${{ inputs.runner }}
     container:
-      image: ghcr.io/dpc-sdp/bay/ci-builder:5.x
+      image: ghcr.io/dpc-sdp/bay/ci-builder:6.x
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Workflows using phpdbg are failing because of a potential version mismatch.

Failed workflow: https://github.com/dpc-sdp/tide_search/actions/runs/10049589699/job/27776497538#step:13:17

```##[debug]sh -e /__w/_temp/2a800aca-ebbd-434b-9a1b-317ff2395b78.sh
==> Generate code coverage report
Error relocating /usr/local/bin/phpdbg: xmlFreeEntity: symbol not found
```