### PR TITLE
[SDPSUP-8298] Updated runner for automated testing.

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   api:
     name: api
-    runs-on: biggy
+    runs-on: biggy-automated-testing
     container:
       image: ghcr.io/dpc-sdp/bay/ci-builder:5.x
     steps:

--- a/.github/workflows/run_e2e_be.yml
+++ b/.github/workflows/run_e2e_be.yml
@@ -57,7 +57,7 @@ on:
         runner:
           type: string
           required: false
-          default: biggy
+          default: biggy-automated-testing
         tag:
           description: SDP testing Docker image tag
           type: string

--- a/.github/workflows/run_e2e_fe.yml
+++ b/.github/workflows/run_e2e_fe.yml
@@ -69,7 +69,7 @@ on:
       runner:
         type: string
         required: false
-        default: biggy
+        default: biggy-automated-testing
       tag:
         description: SDP testing Docker image tag
         type: string


### PR DESCRIPTION
Jira: **https://digital-vic.atlassian.net/browse/SDPSUP-8298**

Sets the default runner for e2e automated tests to the [custom GH runner 'biggy-automated-testing'](https://github.com/organizations/dpc-sdp/settings/actions/github-hosted-runners/4) so that we can whitelist the static IP range and avoid IP rate limiting of test requests.