### PR TITLE
Fix API test in 1.5.0

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -3,6 +3,11 @@ name: api
 on:
   workflow_call:
     inputs:
+      id:
+        description: Test suite ID
+        type: string
+        required: false
+        default: "be_api"
       be_url:
         description: The backend URL for testing
         type: string
@@ -101,6 +106,8 @@ jobs:
     secrets: inherit
     with:
       workflow_name: BE API
+      workflow_id: ${{ inputs.id }}
+      workflow_reusable_name: "run_api_be"
       test_type: ":postman:"
       test_subtype: ":smoke-test:"
       artifact_name: "core-test-report"


### PR DESCRIPTION
Applied the changes that were missed in https://github.com/dpc-sdp/github-actions/pull/41
The other PR https://github.com/dpc-sdp/github-actions/pull/45 enforces the required fields. After we updated the API test CI from 1.4.1 to 1.5.0. The bug breaks the API CI.