### PR TITLE
Fix API test slack notification

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -105,6 +105,7 @@ jobs:
     needs: [api]
     secrets: inherit
     with:
+      state: ${{ needs.api.result }}
       workflow_name: BE API
       workflow_id: ${{ inputs.id }}
       workflow_reusable_name: "run_api_be"

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -40,15 +40,26 @@ on:
         description: Name of the report file
         type: string
         required: true
+      state:
+        description: Check state to set
+        type: string
+        required: false
+        default: ""
 jobs:
   slack_notify:
     name: sdp-test-report
     runs-on: ubuntu-latest
     if: always()
     steps:
+    - name: Set explicitly provided workflow state
+      if: ${{ inputs.state != '' }}
+      run: |
+        echo "WORKFLOW_CONCLUSION=${{ inputs.state }}" >> $GITHUB_ENV
     - name: Wait 15s for previous jobs to conclude
+      if: ${{ inputs.state == '' }}
       run: sleep 15
     - uses: dpc-sdp/workflow-conclusion-action@main
+      if: ${{ inputs.state == '' }}
       with:
         JOB_ID: ${{ inputs.workflow_id }}
         REUSABLE_WORKFLOW_NAME: ${{ inputs.workflow_reusable_name }}


### PR DESCRIPTION
Bypass the workflow conclusion actions for API test, so it will be able to send the notification.
The workflow conclusion actions have a bug that can't handle it properly. We need to look at removing the module in the future. It's out of maintenance. 