### PR TITLE
[SDPPE-100] Bumped image version.

### DIFF
--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
 
-Add permissions block with required permissions used for shipshape audit
+# Add permissions block with required permissions used for shipshape audit
 permissions:
   checks: write
   contents: read


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/SDPPE-100

### Motivation
This change is necessary because if any permissions are set, any permissions that are not set receive the access level of `none`

From [the docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
> If you specify the access for any of these permissions, all of those that are not specified are set to none.

### Changes
* Adds an explicit permission for package access

### Testing
https://github.com/dpc-sdp/content-asbestos-vic-gov-au/actions/runs/16259799500/job/45902539467