### PR TITLE
Set ownership of workspace

### DIFF
--- a/.github/workflows/tide_build.yml
+++ b/.github/workflows/tide_build.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set ownership of the workspace
+        run: chown -R $(id -u):$(id -g) $PWD
       - name: Log into registry ghcr.io
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
### Motivation
The reusable workflow tide_build would throw the following [error when called by a caller](https://github.com/dpc-sdp/tide_core/actions/runs/20357450343/job/58495750468#step:8:10)

```
fatal: detected dubious ownership in repository at '/__w/tide_core/tide_core'
```

### Changes
* Added a step to change the uid of the workspace