### PR TITLE
[SDPPE-317] run_db_trigger: Shutdown container before copying server files

### DIFF
--- a/.github/workflows/run_db_trigger.yml
+++ b/.github/workflows/run_db_trigger.yml
@@ -1,4 +1,4 @@
-name: Reusable workflow to build MySQL database images 
+name: Reusable workflow to build MySQL database images
 
 on:
   workflow_call:
@@ -40,7 +40,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-    
+
 jobs:
   export-db:
     runs-on: ${{ inputs.runner }}
@@ -71,7 +71,7 @@ jobs:
       - name: Download the database
         run: aws s3 cp ${{ inputs.s3_uri }} "${{ env.DB_FILE }}"
 
-      - name: Import the databse into the running container
+      - name: Import the database into the running container
         run: cat "${{ env.DB_FILE }}" | docker exec -i "${{ steps.container.outputs.id }}" /usr/bin/mysql
 
       - name: Verify database is available
@@ -91,7 +91,7 @@ jobs:
         run: docker exec -i "${{ steps.container.outputs.id }}" mysqladmin -u root -p${{ secrets.DB_IMAGE_MARIADB_ROOT_PASSWORD }} shutdown
         continue-on-error: true
 
-      - name: Copy database files out of the intemediary container
+      - name: Copy database files out of the intermediary container
         run: |
           mkdir -p "${{ env.TMP_DATA_DIR }}"
           docker cp "${{ steps.container.outputs.id }}":/var/lib/mysql/. "${{ env.TMP_DATA_DIR }}/"
@@ -127,7 +127,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-          
+
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -145,23 +145,23 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           push: true
-  
+
   notify_slack:
     runs-on: ubuntu-latest
-    needs: [export-db] 
-    if: ${{ always() }}  
+    needs: [export-db]
+    if: ${{ always() }}
     steps:
       - name: Send Notification to Slack on Failure
-        if: ${{ needs.export-db.result == 'failure' }} 
+        if: ${{ needs.export-db.result == 'failure' }}
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ needs.export-db.result }}
           text: 'Attention: The db-trigger workflow has FAILED in project "${{ inputs.project }}" for repo "${{ github.repository }}"!'
-          fields: 'project: ${{ inputs.project }}, repo: ${ { github.repository }}'
+          fields: 'project: ${{ inputs.project }}, repo: ${{ github.repository }}'
           mention: 'here'
           author_name: 'DPC TEAM'
           channel: '#dpc-events'
-          color: 'danger'  
+          color: 'danger'
           if_mention: 'always'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run_db_trigger.yml
+++ b/.github/workflows/run_db_trigger.yml
@@ -87,6 +87,10 @@ jobs:
         run: docker exec "${{ steps.container.outputs.id }}" bash -c "chown -R mysql /var/lib/mysql && /bin/fix-permissions /var/lib/mysql" || true
         continue-on-error: true
 
+      - name: Gracefully shutdown the intermediary container
+        run: docker exec -i "${{ steps.container.outputs.id }}" mysqladmin -u root -p${{ secrets.DB_IMAGE_MARIADB_ROOT_PASSWORD }} shutdown
+        continue-on-error: true
+
       - name: Copy database files out of the intemediary container
         run: |
           mkdir -p "${{ env.TMP_DATA_DIR }}"
@@ -101,10 +105,6 @@ jobs:
             ls -la "${{ env.TMP_DATA_DIR }}"
             exit 1
           fi
-
-      - name: Gracefully shutdown the intermediary container
-        run: docker exec -i "${{ steps.container.outputs.id }}" mysqladmin -u root -p${{ secrets.DB_IMAGE_MARIADB_ROOT_PASSWORD }} shutdown
-        continue-on-error: true
 
       - name: Download the DB image dockerfile
         run: curl -o Dockerfile.seed https://raw.githubusercontent.com/dpc-sdp/github-actions/main/.docker/Dockerfile.seed


### PR DESCRIPTION
In https://digital-vic.atlassian.net/browse/SDPPE-317 we have identified multiple tide repositories with corrupted sanitised database images.

Through local testing I've determined the cause to be this workflow which currently copies server files before it gracefully shuts down the intermediary database container. This change reorders the graceful shutdown step to earlier in the workflow.

Additionally there's a couple of typos and a templating error in the Slack failure message which is now fixed.