### PR TITLE
[SDPPE-295] Update setup-terraform and allow version override

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -17,6 +17,11 @@ on:
         type: string
         required: false
         default: dpc-sdp
+      terraform_version:
+        description: Terraform CLI version to install
+        type: string
+        required: false
+        default: "1.5.7"
 
 env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -45,9 +50,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.5.7
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
 
       - name: Initialize Terraform
         run: terraform init

--- a/.github/workflows/tf_diffscheck.yml
+++ b/.github/workflows/tf_diffscheck.yml
@@ -11,6 +11,11 @@ on:
         type: string
         required: false
         default: "ops"
+      terraform_version:
+        description: Terraform CLI version to install
+        type: string
+        required: false
+        default: "1.5.7"
 
 env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -27,7 +32,7 @@ env:
   CONSTELLIX_API_KEY:  ${{ secrets.CONSTELLIX_API_KEY }}
   CONSTELLIX_SECRET_KEY:  ${{ secrets.CONSTELLIX_SECRET_KEY }}
   QUANTCDN_API_TOKEN: ${{ secrets.QUANT_BEARER }}
-  
+
 jobs:
   diffscheck:
     runs-on: ubuntu-latest
@@ -36,9 +41,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.5.7
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
 
 #      - name: Terraform fmt
 #        id: fmt

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: false
         default: dpc-sdp
+      terraform_version:
+        description: Terraform CLI version to install
+        type: string
+        required: false
+        default: "1.5.7"
 
 env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -29,7 +34,7 @@ env:
   CONSTELLIX_API_KEY:  ${{ secrets.CONSTELLIX_API_KEY }}
   CONSTELLIX_SECRET_KEY:  ${{ secrets.CONSTELLIX_SECRET_KEY }}
   QUANTCDN_API_TOKEN: ${{ secrets.QUANT_BEARER }}
-  
+
 jobs:
   plan:
     runs-on: ubuntu-latest
@@ -38,9 +43,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.5.7
+          terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
 
 #      - name: Terraform fmt
@@ -66,7 +71,7 @@ jobs:
           then
             exit 0
           else
-            exit $exitcode  
+            exit $exitcode
           fi
 
       - name: Check Terraform Plan


### PR DESCRIPTION
Terraform 1.5.7 is ancient and out of support. This change allows us to override this on downstream projects until the default can be bumped higher.

Also updates the setup-terraform action to the latest version. Changelog here: https://github.com/hashicorp/setup-terraform/blob/main/CHANGELOG.md (mostly just the nodeJS upgrade to 24)