### PR TITLE
ci(test): gha dd

### DIFF
--- a/.github/workflows/test_e2e_be.yml
+++ b/.github/workflows/test_e2e_be.yml
@@ -122,17 +122,22 @@ jobs:
           curl ${TEST_BE_BASE_URL} -s -S --max-time 1000 --write-out '%{http_code}' --output /dev/null;
       -
         name: Enable Datadog tracing if available
+        id: dd_trace_check
         shell: bash
         run: |
-          if node -e "require.resolve('dd-trace/ci/init')"; then
-            echo "NODE_OPTIONS=-r dd-trace/ci/init" >> "$GITHUB_ENV"
+          if node -e "require.resolve('dd-trace/ci/init')" 2>/dev/null; then
+            echo "dd-trace is available; enabling Datadog tracing"
+            echo "node_options=-r dd-trace/ci/init" >> "$GITHUB_OUTPUT"
           else
             echo "dd-trace not available; continuing without Datadog tracing"
+            echo "node_options=" >> "$GITHUB_OUTPUT"
           fi
       -
         name: Run Backend tests
         run: |
           npm run e2e:backend -- -g "${{ inputs.tags }}"
+        env:
+          NODE_OPTIONS: ${{ steps.dd_trace_check.outputs.node_options }}
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test_e2e_be.yml
+++ b/.github/workflows/test_e2e_be.yml
@@ -86,7 +86,7 @@ env:
   FTP_JIRA_EMAIL: ${{ secrets.TEST_FTP_JIRA_EMAIL }}
   FTP_JIRA_API_TOKEN: ${{ secrets.TEST_FTP_JIRA_API_TOKEN }}
   # Settings
-  DD_API_KEY: ${{ secrets.DD_API_KEY }}
+  DD_API_KEY: ${{ secrets.TEST_DD_API_KEY }}
   DD_ENV: ci
   DD_SERVICE: sdp-testing-playwright
   DD_SITE: ap2.datadoghq.com

--- a/.github/workflows/test_e2e_be.yml
+++ b/.github/workflows/test_e2e_be.yml
@@ -121,11 +121,18 @@ jobs:
         run: |
           curl ${TEST_BE_BASE_URL} -s -S --max-time 1000 --write-out '%{http_code}' --output /dev/null;
       -
+        name: Enable Datadog tracing if available
+        shell: bash
+        run: |
+          if node -e "require.resolve('dd-trace/ci/init')"; then
+            echo "NODE_OPTIONS=-r dd-trace/ci/init" >> "$GITHUB_ENV"
+          else
+            echo "dd-trace not available; continuing without Datadog tracing"
+          fi
+      -
         name: Run Backend tests
         run: |
           npm run e2e:backend -- -g "${{ inputs.tags }}"
-        env:
-          NODE_OPTIONS: '-r dd-trace/ci/init'
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test_e2e_be.yml
+++ b/.github/workflows/test_e2e_be.yml
@@ -86,7 +86,12 @@ env:
   FTP_JIRA_EMAIL: ${{ secrets.TEST_FTP_JIRA_EMAIL }}
   FTP_JIRA_API_TOKEN: ${{ secrets.TEST_FTP_JIRA_API_TOKEN }}
   # Settings
-
+  DD_API_KEY: ${{ secrets.DD_API_KEY }}
+  DD_ENV: ci
+  DD_SERVICE: sdp-testing-playwright
+  DD_SITE: ap2.datadoghq.com
+  DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
+  DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: 'false'
 
 jobs:
   test_e2e_be:
@@ -119,6 +124,8 @@ jobs:
         name: Run Backend tests
         run: |
           npm run e2e:backend -- -g "${{ inputs.tags }}"
+        env:
+          NODE_OPTIONS: '-r dd-trace/ci/init'
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test_e2e_fe.yml
+++ b/.github/workflows/test_e2e_fe.yml
@@ -89,7 +89,7 @@ env:
   # Settings
   GIT_BRANCH: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
   GHA_RUN_ID: ${{ github.run_id }}
-  DD_API_KEY: ${{ secrets.DD_API_KEY }}
+  DD_API_KEY: ${{ secrets.TEST_DD_API_KEY }}
   DD_ENV: ci
   DD_SERVICE: sdp-testing-playwright
   DD_SITE: ap2.datadoghq.com

--- a/.github/workflows/test_e2e_fe.yml
+++ b/.github/workflows/test_e2e_fe.yml
@@ -131,17 +131,22 @@ jobs:
           curl ${TEST_FE_BASE_URL} -s -S --max-time 1000 --write-out '%{http_code}' --output /dev/null;
       -
         name: Enable Datadog tracing if available
+        id: dd_trace_check
         shell: bash
         run: |
-          if node -e "require.resolve('dd-trace/ci/init')"; then
-            echo "NODE_OPTIONS=-r dd-trace/ci/init" >> "$GITHUB_ENV"
+          if node -e "require.resolve('dd-trace/ci/init')" 2>/dev/null; then
+            echo "dd-trace is available; enabling Datadog tracing"
+            echo "node_options=-r dd-trace/ci/init" >> "$GITHUB_OUTPUT"
           else
             echo "dd-trace not available; continuing without Datadog tracing"
+            echo "node_options=" >> "$GITHUB_OUTPUT"
           fi
       -
         name: Run Frontend tests
         run: |
           npm run e2e:frontend -- -g "${{ inputs.tags }}"
+        env:
+          NODE_OPTIONS: ${{ steps.dd_trace_check.outputs.node_options }}
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test_e2e_fe.yml
+++ b/.github/workflows/test_e2e_fe.yml
@@ -130,11 +130,18 @@ jobs:
           curl ${TEST_BE_BASE_URL} -s -S --max-time 1000 --write-out '%{http_code}' --output /dev/null;
           curl ${TEST_FE_BASE_URL} -s -S --max-time 1000 --write-out '%{http_code}' --output /dev/null;
       -
+        name: Enable Datadog tracing if available
+        shell: bash
+        run: |
+          if node -e "require.resolve('dd-trace/ci/init')"; then
+            echo "NODE_OPTIONS=-r dd-trace/ci/init" >> "$GITHUB_ENV"
+          else
+            echo "dd-trace not available; continuing without Datadog tracing"
+          fi
+      -
         name: Run Frontend tests
         run: |
           npm run e2e:frontend -- -g "${{ inputs.tags }}"
-        env:
-          NODE_OPTIONS: '-r dd-trace/ci/init'
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test_e2e_fe.yml
+++ b/.github/workflows/test_e2e_fe.yml
@@ -89,7 +89,13 @@ env:
   # Settings
   GIT_BRANCH: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
   GHA_RUN_ID: ${{ github.run_id }}
-
+  DD_API_KEY: ${{ secrets.DD_API_KEY }}
+  DD_ENV: ci
+  DD_SERVICE: sdp-testing-playwright
+  DD_SITE: ap2.datadoghq.com
+  DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
+  DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: 'false'
+  
 jobs:
   test_e2e_fe:
     name: test_e2e_fe
@@ -127,6 +133,8 @@ jobs:
         name: Run Frontend tests
         run: |
           npm run e2e:frontend -- -g "${{ inputs.tags }}"
+        env:
+          NODE_OPTIONS: '-r dd-trace/ci/init'
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
* Add dd trace for FE and BE playwright runs. Note all branches will have results like develop, uat, master, production runs https://ap2.datadoghq.com/ci/test/runs?query=test_level%3Atest&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&start=1781742605758&end=1782347405758&paused=false

* Playwright test implementation on project level use @main due to wanting flexibility with updating any issues so after merging this - all projects should start being captured
* Note it requires sdp-testing-playwright 1.60.x image 